### PR TITLE
#18 fix security vulnerabilities in servlet example

### DIFF
--- a/example/search-example-servlet/README.md
+++ b/example/search-example-servlet/README.md
@@ -8,6 +8,15 @@ It build upon the search menu example UI in the outer directory.
 The servlet source code can be found here: [MultiSearchTemplateServlet.java](/src/main/java/io/github/joht/search/example/servlet/MultiSearchTemplateServlet.java).
 
 This is only a very simple example to get started. It doesn't accept other requests than multi template searches, doesn't include TLS (SSL) setup, has no additional authentication or authorization setup, .... 
+
+# Prerequisites
+
+- Run the following command so that the directory above contains the `node_modules` directory:
+
+```shell
+../npm install
+```
+
 ## Running the application in dev mode
 
 You can run your application in dev mode that enables live coding using:

--- a/example/search-example-servlet/pom.xml
+++ b/example/search-example-servlet/pom.xml
@@ -16,6 +16,7 @@
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
+    <json-sanitizer.version>1.2.2</json-sanitizer.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
     <mockito-core.version>4.1.0</mockito-core.version>
@@ -54,6 +55,12 @@
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>elasticsearch-rest-client</artifactId>
+    </dependency>
+    <!--  OWASP JSON Sanatizer (XSS Security Protection) -->
+    <dependency>
+      <groupId>com.mikesamuel</groupId>
+      <artifactId>json-sanitizer</artifactId>
+      <version>${json-sanitizer.version}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/example/search-example-servlet/src/main/java/io/github/joht/search/example/servlet/MultiSearchTemplateServlet.java
+++ b/example/search-example-servlet/src/main/java/io/github/joht/search/example/servlet/MultiSearchTemplateServlet.java
@@ -10,6 +10,9 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import com.google.json.JsonSanitizer;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.util.EntityUtils;
@@ -74,9 +77,11 @@ public class MultiSearchTemplateServlet extends HttpServlet {
     private void updateHttpResponse(HttpEntity entity, final HttpServletResponse httpResponse) throws IOException {
         httpResponse.setContentType(entity.getContentType().getValue());
         try (PrintWriter printWriter = httpResponse.getWriter();) {
-            String elasticSearchResponse = EntityUtils.toString(entity);
+            final String elasticSearchResponse = EntityUtils.toString(entity);
             LOGGER.finer(() -> "Response from Elasticsearch: " + elasticSearchResponse);
-            printWriter.println(elasticSearchResponse);
+            String encodedResponse = JsonSanitizer.sanitize(elasticSearchResponse);
+            LOGGER.finer(() -> "Encoded response from Elasticsearch: " + encodedResponse);
+            printWriter.println(encodedResponse);
         }
     }
 }

--- a/example/search-example-servlet/src/main/java/io/github/joht/search/example/servlet/SearchRequestAdapter.java
+++ b/example/search-example-servlet/src/main/java/io/github/joht/search/example/servlet/SearchRequestAdapter.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Map.Entry;
+import java.util.logging.Logger;
+
 import javax.servlet.http.HttpServletRequest;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
@@ -25,11 +27,13 @@ import org.elasticsearch.client.RequestOptions.Builder;
  */
 class SearchRequestAdapter {
 
-    private static final List<String> HEADERS_TO_IGNORE_BY_DEFAULT =
-            Arrays.asList("Content-Length", "Content-Type");
+    private static final Logger LOGGER = Logger.getLogger(SearchRequestAdapter.class.getName());
+
+    private static final List<String> ALLOWED_HEADERS =
+            Arrays.asList("Accept", "Accept-Encoding", "Accept-Language", "Authorization", "Connection", "Contest-Length", "es-secondary-authorization", "Host", "Origin", "Referer", "User-Agent");
 
     private final HttpServletRequest httpRequest;
-    private final Collection<String> headersToIgnore = new ArrayList<>(HEADERS_TO_IGNORE_BY_DEFAULT);
+    private final Collection<String> allowedHeaders = new ArrayList<>(ALLOWED_HEADERS);
     private int bodyReaderBufferSize = 1024;
 
     public static final SearchRequestAdapter adapt(HttpServletRequest httpRequest) {
@@ -40,8 +44,8 @@ class SearchRequestAdapter {
         this.httpRequest = Objects.requireNonNull(httpRequest, () -> "httpRequest may not be null");
     }
 
-    public SearchRequestAdapter addHeaderToIgnore(String headerName) {
-        headersToIgnore.add(Objects.requireNonNull(headerName, () -> "header may not be null"));
+    public SearchRequestAdapter addAllowedHeader(String headerName) {
+        allowedHeaders.add(Objects.requireNonNull(headerName, () -> "header may not be null"));
         return this;
     }
 
@@ -50,8 +54,8 @@ class SearchRequestAdapter {
         return this;
     }
 
-    public Collection<String> getHeadersToIgnore() {
-        return Collections.unmodifiableCollection(headersToIgnore);
+    public Collection<String> getAllowedHeaders() {
+        return Collections.unmodifiableCollection(allowedHeaders);
     }
 
     public int getBodyReaderBufferSize() {
@@ -69,8 +73,9 @@ class SearchRequestAdapter {
     private RequestOptions headersToSearchRequestOptions() {
         Builder searchRequestOptions = RequestOptions.DEFAULT.toBuilder();
         for (String headerName : Collections.list(httpRequest.getHeaderNames())) {
-            if (!headersToIgnore.contains(headerName)) {
+            if (allowedHeaders.contains(headerName)) {
                 searchRequestOptions.addHeader(headerName, httpRequest.getHeader(headerName));
+                LOGGER.finer(() -> "Adding header " + headerName + " with value " + httpRequest.getHeader(headerName));
             }
         }
         return searchRequestOptions.build();
@@ -79,6 +84,8 @@ class SearchRequestAdapter {
     private HttpEntity bodyToSearchRequestEntity() throws IOException {
         String searchBody = getBody();
         ContentType searchContentType = ContentType.create(httpRequest.getContentType());
+        LOGGER.finer(() -> "Search body: " + searchBody);
+        LOGGER.finer(() -> "Search content type: " + searchContentType);
         return new NStringEntity(searchBody, searchContentType);
     }
 
@@ -100,6 +107,7 @@ class SearchRequestAdapter {
         for (Entry<K, V[]> entry : map.entrySet()) {
             result.put(entry.getKey(), getFirstArrayValue(entry.getValue()));
         }
+        LOGGER.finer(() -> "First array values: " + result);
         return result;
     }
 
@@ -109,6 +117,7 @@ class SearchRequestAdapter {
 
     @Override
     public String toString() {
-        return "SearchRequestAdapter [httpRequest=" + httpRequest + "]";
+        return "SearchRequestAdapter [allowedHeaders=" + allowedHeaders + ", bodyReaderBufferSize="
+                + bodyReaderBufferSize + ", httpRequest=" + httpRequest + "]";
     }
 }

--- a/example/search-example-servlet/src/test/java/io/github/joht/search/example/servlet/SearchRequestAdapterTest.java
+++ b/example/search-example-servlet/src/test/java/io/github/joht/search/example/servlet/SearchRequestAdapterTest.java
@@ -15,7 +15,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.http.Header;
@@ -88,18 +87,18 @@ class SearchRequestAdapterTest {
     }
 
     @Test
-    @DisplayName("it should take an header name to ignore and return it in the list of ignored headers")
-    void nameOfHeaderToIgnoreAdded() {
-        String expectedHeaderName = "headerNameToIgnore";
-        adapterUnderTest.addHeaderToIgnore(expectedHeaderName);
-        assertThat(adapterUnderTest.getHeadersToIgnore(), hasItem(expectedHeaderName));
+    @DisplayName("it should take a header name that is added to the list of allowed headers")
+    void nameOfHeaderToBeAdded() {
+        String expectedHeaderName = "additionalAllowedHeaderName";
+        adapterUnderTest.addAllowedHeader(expectedHeaderName);
+        assertThat(adapterUnderTest.getAllowedHeaders(), hasItem(expectedHeaderName));
     }
 
-    @ParameterizedTest(name = "it should ignore the {0} header by default ({index})")
-    @DisplayName("it should ignore some headers by default")
-    @ValueSource(strings = {"Content-Length", "Content-Type"})
+    @ParameterizedTest(name = "it should accept the {0} header by default ({index})")
+    @DisplayName("it should accept some headers by default")
+    @ValueSource(strings = {"Accept", "Accept-Encoding", "Accept-Language", "Authorization", "Connection", "Contest-Length", "es-secondary-authorization", "Host", "Origin", "Referer", "User-Agent"})
     void headerToIgnoreByDefault(String expectedHeaderName) {
-        assertThat(adapterUnderTest.getHeadersToIgnore(), hasItem(expectedHeaderName));
+        assertThat(adapterUnderTest.getAllowedHeaders(), hasItem(expectedHeaderName));
     }
 
     @Test
@@ -164,21 +163,21 @@ class SearchRequestAdapterTest {
     }
 
     @Test
-    @DisplayName("it should use the same custom HTTP headers as the incoming request for elasticsearch")
+    @DisplayName("it should use the same custom HTTP headers as the incoming request if they are in the list of allowed headers")
     void elasticSearchRequest() throws IOException {
-        Collection<String> headerNames = Arrays.asList("CustomTestHeader1", "CustomTestHeader2");
+        Collection<String> headerNames = Arrays.asList("Accept", "Origin");
         when(httpRequest.getHeaderNames()).thenReturn(Collections.enumeration(headerNames));
-        when(httpRequest.getHeader("CustomTestHeader1")).thenReturn("1");
-        when(httpRequest.getHeader("CustomTestHeader2")).thenReturn("2");
+        when(httpRequest.getHeader("Accept")).thenReturn("*/*");
+        when(httpRequest.getHeader("Origin")).thenReturn("localhost");
 
         Request request = adapterUnderTest.toElasticSearchRequest();
         Map<String, String> searchHeaders = request.getOptions().getHeaders().stream().collect(Collectors.toMap(Header::getName, Header::getValue));
-        assertThat(searchHeaders.get("CustomTestHeader1"), equalTo("1"));
-        assertThat(searchHeaders.get("CustomTestHeader2"), equalTo("2"));
+        assertThat(searchHeaders.get("Accept"), equalTo("*/*"));
+        assertThat(searchHeaders.get("Origin"), equalTo("localhost"));
     }
 
     @Test
-    @DisplayName("it shouldn't transfer headers that were defined to be ignored")
+    @DisplayName("it shouldn't transfer headers that are not defined in the list of allowed headers")
     void elasticSearchRequestWithoutIgnoredHeaders() throws IOException {
         Collection<String> headerNames = Arrays.asList("Content-Type", "Content-Length");
         when(httpRequest.getHeaderNames()).thenReturn(Collections.enumeration(headerNames));


### PR DESCRIPTION
Resolves issue #18.

### Security improvements of the servlet example:
- Log IOException and respond with Log ID
- Header allow list instead of block list
- Sanatize elasticsearch json response
- Sanatize headers into elasticsearch